### PR TITLE
Use `table[]`

### DIFF
--- a/builtin/mainmenu/dlg_server_list_mods.lua
+++ b/builtin/mainmenu/dlg_server_list_mods.lua
@@ -5,43 +5,47 @@
 local function get_formspec(dialogdata)
 	local TOUCH_GUI = core.settings:get_bool("touch_gui")
 	local server = dialogdata.server
-	local filter_prefix = dialogdata.filter_prefix
+	local group_by_prefix = dialogdata.group_by_prefix
+	local expand_all = dialogdata.expand_all
 
 	-- A wrongly behaving server may send ill formed mod names
-	local mods = {}
 	table.sort(server.mods)
 
-	if filter_prefix == true then -- All prefixes
-		mods = server.mods
-	elseif filter_prefix then
+	local cells = {}
+	if group_by_prefix then
+		local function get_prefix(mod)
+			return mod:match("[^_]*")
+		end
+		local count = {}
 		for _, mod in ipairs(server.mods) do
-			if mod == filter_prefix or mod:sub(0, #filter_prefix + 1) == filter_prefix .."_" then
-				table.insert(mods, core.formspec_escape(mod))
-			end
+			local prefix = get_prefix(mod)
+			count[prefix] = (count[prefix] or 0) + 1
 		end
-	else
 		local last_prefix
-		for i, mod in ipairs(server.mods) do
-			local prefix = mod:match("([^_]*)_") or mod
-			if prefix and last_prefix == prefix then
-				mods[#mods] = "#BBBBBB▶ ".. core.formspec_escape(prefix)
-			else
-				table.insert(mods, core.formspec_escape(mod))
-				last_prefix = prefix
-			end
+		local function add_row(depth, mod)
+			table.insert(cells, ("%d"):format(depth))
+			table.insert(cells, mod)
 		end
-	end
-	dialogdata.mods = mods
-	mods = table.concat(mods, ",")
-
-	local prefix_button_label
-	if not filter_prefix then
-		prefix_button_label = fgettext("Expand all prefixes")
-	elseif filter_prefix == true then
-		prefix_button_label = fgettext("Group by prefix")
+		for i, mod in ipairs(server.mods) do
+			local prefix = get_prefix(mod)
+			if last_prefix == prefix then
+				add_row(1, mod)
+			elseif count[prefix] > 1 then
+				add_row(0, prefix)
+				add_row(1, mod)
+			else
+				add_row(0, mod)
+			end
+			last_prefix = prefix
+		end
 	else
-		prefix_button_label = fgettext("Show all mods")
+		cells = table.copy(server.mods)
 	end
+
+	for i, cell in ipairs(cells) do
+		cells[i] = core.formspec_escape(cell)
+	end
+	cells = table.concat(cells, ",")
 
 	local heading
 	if server.gameid then
@@ -55,12 +59,17 @@ local function get_formspec(dialogdata)
 
 	local formspec = {
 		"formspec_version[8]",
-		"size[6,9.5]",
+		"size[8,9.5]",
 		TOUCH_GUI and "padding[0.01,0.01]" or "",
-		"hypertext[0,0;6,1.5;;<global margin=5 halign=center valign=middle>".. heading .. "]",
-		"textlist[0.5,1.5;5,6.8;mods;" .. mods .. "]",
-		"button[0.5,8.5;3,0.8;prefix;" .. prefix_button_label .. "]",
-		"button[3.5,8.5;2,0.8;quit;OK]"
+		"hypertext[0,0;8,1.5;;<global margin=5 halign=center valign=middle>", heading, "]",
+		"tablecolumns[", group_by_prefix and
+			(expand_all and "indent;text" or "tree;text") or "text", "]",
+		"table[0.5,1.5;7,6.8;mods;", cells, "]",
+		"checkbox[0.5,8.7;group_by_prefix;", fgettext("Group by prefix"), ";",
+			group_by_prefix and "true" or "false", "]",
+		group_by_prefix and ("checkbox[0.5,9.15;expand_all;" .. fgettext("Expand all") .. ";" ..
+			(expand_all and "true" or "false") .. "]") or "",
+		"button[5.5,8.5;2,0.8;quit;OK]"
 	}
 	return table.concat(formspec, "")
 end
@@ -71,23 +80,13 @@ local function buttonhandler(this, fields)
 		return true
 	end
 
-	if fields.mods then
-		local exploded = core.explode_textlist_event(fields.mods)
-		if exploded.type == "DCL" then
-			local match = this.data.mods[exploded.index]:match("#BBBBBB▶ ([^_]*)")
-			if match then
-				this.data.filter_prefix = match
-				return true
-			end
-		end
+	if fields.group_by_prefix then
+		this.data.group_by_prefix = core.is_yes(fields.group_by_prefix)
+		return true
 	end
 
-	if fields.prefix then
-		if this.data.filter_prefix then
-			this.data.filter_prefix = nil
-		else
-			this.data.filter_prefix = true
-		end
+	if fields.expand_all then
+		this.data.expand_all = core.is_yes(fields.expand_all)
 		return true
 	end
 
@@ -99,6 +98,8 @@ function create_server_list_mods_dialog(server)
 		get_formspec,
 		buttonhandler,
 		nil)
+	retval.data.group_by_prefix = false
+	retval.data.expand_all = false
 	retval.data.server = server
 	return retval
 end


### PR DESCRIPTION
Uses a `table[]` to show the tree of mods with collapsible "categories" based on prefixes instead of manually implementing it.

I also made the formspec a bit wider so long mod names wouldn't unnecessarily get cut off:

![Screenshot from 2025-01-10 11-43-45](https://github.com/user-attachments/assets/20b0b9ae-9351-4595-b103-a17baeb9c8d4)

